### PR TITLE
flag 변수 제거

### DIFF
--- a/GarticUmm/Form2.cs
+++ b/GarticUmm/Form2.cs
@@ -12,7 +12,6 @@ namespace GarticUmm
         Graphics g;
         int x = -1;
         int y = -1;
-        int flag = 0;
         bool moving = false;
         Pen pen;
         SolidBrush brush;
@@ -200,10 +199,8 @@ namespace GarticUmm
             else if(e.Button == eraserbtn)
             {
                 Set_initial();
-                flag = 1;
-                panel.Refresh();
                 ClearDrawingHistory();
-                
+                panel.Refresh();  
             }
             
             else if (e.Button == redbtn)
@@ -314,12 +311,6 @@ namespace GarticUmm
 
         private void panel_Paint(object sender, PaintEventArgs e)
         {
-            if (flag != 0)
-            {
-                flag = 0;
-                return;
-            };
-
             drawFromHistory();
         }
 


### PR DESCRIPTION
1. e.Button == eraserbtn 이 부분에서 panel.Refresh 가 실행 되면 panel_Paint 이벤트가 일어나는 걸로 예상.
2. 이 때문에 panel.Refresh 뒤에 ClearDrawingHistory를 실행 하면 DrawingHistory에 대한 정보가 남아있음.
3. 그래서 panel.Refresh가 실행되면 panel_Paint가 발생하고 DrawingHistory에 대한 정보가 남아있기 때문에 그림을 다시 그리게 되고, 후에 DrawingHistory에 대한 정보가 지워져 지우개 버튼을 한 번 더 클릭해야 그림이 지워짐.
4. 그러므로 ClearDrawingHistory를 먼저 실행하면 panel.Refresh 로 인해 panel_Paint가 발생해도 DrawingHistory에 대한 정보가 없으므로 그림을 다시 안 그림.
5. 따라서 정상적으로 지우개 버튼이 작동해 flag 변수를 안써도 됨.