### PR TITLE
채팅창 버그 수정

### DIFF
--- a/GarticUmm/SocketClient.cs
+++ b/GarticUmm/SocketClient.cs
@@ -79,10 +79,9 @@ namespace GarticUmm
             if (!isConnected) return;
 
             NetworkStream stream = clientSocket.GetStream();
-            StreamWriter writer = new StreamWriter(stream, Constant.UTF8);
+            StreamWriter writer = new StreamWriter(stream, Constant.UTF8) { AutoFlush = true };
             
             writer.WriteLine(message);
-            writer.Flush();
         }
     }
 }

--- a/GarticUmm/SocketServer.cs
+++ b/GarticUmm/SocketServer.cs
@@ -55,7 +55,7 @@ namespace GarticUmm
                         h_client.StartClient(client, connectionCount);
                         clients.Add(h_client);
 
-                        onReceiveHandler(new ResClass(1000, h_client.ID + " Player had been joined."));
+                        // Send message at HandleClient.ClientThreadHandler
                         Console.WriteLine(h_client.ID + " Player had been joined.");
                     }
                     catch 
@@ -74,9 +74,9 @@ namespace GarticUmm
 
         public void ServerStop()
         {
-            foreach(var client in clients)
+            for (int i = 0; i < clients.Count; i++)
             {
-                client.StopClient();
+                clients[i]?.StopClient();
             }
 
             isRunning = false;
@@ -90,7 +90,6 @@ namespace GarticUmm
                 try
                 {
                     client.StreamWriter.WriteLine(res.Message);
-                    client.StreamWriter.Flush();
                 }
                 catch
                 {
@@ -150,19 +149,22 @@ namespace GarticUmm
                 stream = clientSocket.GetStream();
 
                 reader = new StreamReader(stream, Constant.UTF8);
-                writer = new StreamWriter(stream, Constant.UTF8);
+                writer = new StreamWriter(stream, Constant.UTF8) { AutoFlush = true };
 
-                while (true)
+                OnReceived(new ResClass(1000, clientID + " Player had been joined."));
+
+                while (isConnected)
                 {
                     string str = reader.ReadLine();
-
-                    if (!isConnected) break;
-
                     Console.WriteLine("[IN] {0}: {1}", clientID, str);
+
+                    // 연결이 끊긴 경우에만 null값이 들어옴
+                    if (str == null) break;
 
                     if (OnReceived != null)
                     {
                         OnReceived(new ResClass(1000, clientID + " > "+ str));
+                        Console.WriteLine("[OUT] {0}: {1}", clientID, str);
                     }
                 }
             }


### PR DESCRIPTION
- `AutoFlush` 적용
이제 매번 Flush 메서드를 호출 안 해도 됩니다.

- Player 입장 메시지 전송 시점 변경
비동기 처리 관련 문제 때문에 **tcp 연결 및 스레드 생성 전**에 메세지가 보내지는 것 같아 보였음.
따라서 **스레드 생성 후** 메세지를 보내도록 수정했습니다.

- `ServerStop`시 Collection 변경으로 인한 `foreach` 순환 오류 수정
대신 `for` 문으로 수정했습니다.

- 접속 종료시 공백문자 전송 삭제
접속 종료시 ReadLine이 종료됨에 따라 `str` 값에 `null`값이 전달되고, 이 것이 `isConnected` 가 `false` 로 변경되기 **전**에
먼저 발생하여 빈 문자가 전송되는 문제를 해결했습니다.
간단하게 `str` 이 `null` 이 아닌지 검사하는 방식으로 진행했습니다.