### PR TITLE
이벤트 코드가 4000일 때 채팅 처리

### DIFF
--- a/GarticUmm/SocketServer.cs
+++ b/GarticUmm/SocketServer.cs
@@ -7,9 +7,11 @@ using System.Linq;
 using System.Net;
 using System.Net.Sockets;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using SharedObject;
+using UmmQueue;
 
 namespace GarticUmm
 {
@@ -162,14 +164,19 @@ namespace GarticUmm
                 {
                     string str = reader.ReadLine();
                     Console.WriteLine("[IN] {0}: {1}", clientID, str);
-
                     // 연결이 끊긴 경우에만 null값이 들어옴
                     if (str == null) break;
 
+                    string Code = str.Substring(0, str.IndexOf(','));
+                    string Data = str.Substring(str.IndexOf(',') + 1).Trim();
+               
                     if (OnReceived != null)
                     {
-                        OnReceived(new ResClass(1000, clientID + " > "+ str));
-                        Console.WriteLine("[OUT] {0}: {1}", clientID, str);
+                        if (Regex.IsMatch(Code, "4000"))
+                         {
+                            OnReceived(new ResClass(1000, clientID + " > " + Data));
+                            Console.WriteLine("[OUT] {0}: {1}", clientID, Data);
+                        }
                     }
                 }
             }

--- a/GarticUmm/SocketServer.cs
+++ b/GarticUmm/SocketServer.cs
@@ -167,12 +167,16 @@ namespace GarticUmm
                     // 연결이 끊긴 경우에만 null값이 들어옴
                     if (str == null) break;
 
-                    string Code = str.Substring(0, str.IndexOf(','));
+                    string pat = "\\d+";
+                    Regex re = new Regex(pat);
+
+                    string temp = str.Substring(0, str.IndexOf(','));
+                    string Code = re.Match(temp).Value;
                     string Data = str.Substring(str.IndexOf(',') + 1).Trim();
                
                     if (OnReceived != null)
                     {
-                        if (Regex.IsMatch(Code, "4000"))
+                        if (Code == "4000")
                          {
                             OnReceived(new ResClass(1000, clientID + " > " + Data));
                             Console.WriteLine("[OUT] {0}: {1}", clientID, Data);

--- a/GarticUmm/SocketServer.cs
+++ b/GarticUmm/SocketServer.cs
@@ -167,20 +167,18 @@ namespace GarticUmm
                     // 연결이 끊긴 경우에만 null값이 들어옴
                     if (str == null) break;
 
-                    string pat = "\\d+";
-                    Regex re = new Regex(pat);
+                    string pattern = "\\d+";
+                    Regex reg = new Regex(pattern);
 
                     string temp = str.Substring(0, str.IndexOf(','));
-                    string Code = re.Match(temp).Value;
-                    string Data = str.Substring(str.IndexOf(',') + 1).Trim();
+                    string code = reg.Match(temp).Value;
+                    string strData = str.Substring(str.IndexOf(',') + 1).Trim();
                
                     if (OnReceived != null)
-                    {
-                        if (Code == "4000")
-                         {
-                            OnReceived(new ResClass(1000, clientID + " > " + Data));
-                            Console.WriteLine("[OUT] {0}: {1}", clientID, Data);
-                        }
+                    {    
+                        OnReceived(new ResClass(int.Parse(code), clientID + " > " + strData));
+                         Console.WriteLine("[OUT] {0}: {1}", clientID, strData);
+ 
                     }
                 }
             }


### PR DESCRIPTION
1. Code에는 이벤트 코드가 저장됨.
2. Data에는 받은 정보가 저장됨.
3. 이벤트 코드를 처리하는 과정에서, 각 클라이언트가 처음으로 보낸 메시지를 처리 할 때는 문제가 없었음. 
하지만 두 번째 메시지를 처리 할 때부터 디버깅 로그에서만 보이는 ?값이 메시지 앞에 붙음. 
이 때문에 (Code == "4000") 이런 식으로 처리하면 같다고 인식을 안함. 
그래서 임시 방편으로 일단 Code의 값이 4000을 포함하고 있으면 처리하는 식으로 구현.