### PR TITLE
3명 이상 접속 후 게임 시작시 서버 중단 현상 수정

### DIFF
--- a/GarticUmm/Form2.cs
+++ b/GarticUmm/Form2.cs
@@ -393,7 +393,7 @@ namespace GarticUmm
                 if(res.Message == Constant.GAME_START)
                 {
                     GUWordForm wordForm = new GUWordForm();
-                    wordForm.DataPass += new GUWordForm.DataPassEventHandler(ReciveWord);
+                    wordForm.DataPass += ReciveWord;
                     wordForm.ShowDialog();
                 }
             }

--- a/GarticUmm/SharedObject.cs
+++ b/GarticUmm/SharedObject.cs
@@ -10,8 +10,8 @@ namespace SharedObject
 {
     class Constant
     {
-        public static readonly IPAddress LOCALHOST = IPAddress.Parse("127.0.0.1");
-        // public static readonly IPAddress LOCALHOST = IPAddress.Parse("192.168.182.194");
+        //public static readonly IPAddress LOCALHOST = IPAddress.Parse("127.0.0.1");
+        public static readonly IPAddress LOCALHOST = IPAddress.Parse("192.168.182.194");
         public static readonly int PORT = 43673;
         public static readonly Encoding UTF8 = Encoding.GetEncoding("UTF-8");
 

--- a/GarticUmm/SocketServer.cs
+++ b/GarticUmm/SocketServer.cs
@@ -153,7 +153,14 @@ namespace GarticUmm
 
                     foreach(int id in playQueue)
                     {
-                        clients[id].StreamWriter.WriteLine("2004," + Constant.GAME_START);
+                        Console.WriteLine("send start signal to " + id);
+                        foreach (HandleClient client in clients)
+                        {
+                            if (client.ID == id)
+                            {
+                                client.StreamWriter.WriteLine("2004," + Constant.GAME_START);
+                            }
+                        }
                     }
                 }
             }
@@ -243,9 +250,10 @@ namespace GarticUmm
                     }
                 }
             }
-            catch
+            catch (Exception ex)
             {
                 Console.WriteLine("-- Client Thread Handler Exception --");
+                Console.WriteLine(ex.StackTrace);
             }
 
             OnDisconnect(this);

--- a/GarticUmm/UmmQueue.cs
+++ b/GarticUmm/UmmQueue.cs
@@ -34,7 +34,7 @@ namespace UmmQueue
         public void enQueue(T person)
         {
             Node<T> newnode = new Node<T>(person);
-            if (last == null)
+            if (first == null)
             {
                 first = newnode;
                 last = newnode;
@@ -42,7 +42,7 @@ namespace UmmQueue
             else
             {
                 last.next = newnode;
-                last = newnode;
+                last = last.next;
             }
             size++;
         }
@@ -54,8 +54,10 @@ namespace UmmQueue
 
             Node<T> result = first;
             first = first.next;
+
             if (first == null)
                 last = null;
+
             size--;
             return result.value;
         }


### PR DESCRIPTION
- `socket server`에서 각 **client**에 메시지를 보낼 때의 **index**부분 수정
이중 foreach문을 사용하여 실제 client.id와 playerqueue에 들어 있는 id를 비교하여 일치하는 경우에만 전송