### PR TITLE
fix issues at #37

### DIFF
--- a/GarticUmm.sln
+++ b/GarticUmm.sln
@@ -12,7 +12,6 @@ Global
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{B66101C7-46B2-48CB-BDB8-4B370FD6A2DA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{B66101C7-46B2-48CB-BDB8-4B370FD6A2DA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B66101C7-46B2-48CB-BDB8-4B370FD6A2DA}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B66101C7-46B2-48CB-BDB8-4B370FD6A2DA}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection

--- a/GarticUmm/Form2.Designer.cs
+++ b/GarticUmm/Form2.Designer.cs
@@ -45,11 +45,14 @@ namespace GarticUmm
             this.whitebtn = new System.Windows.Forms.ToolBarButton();
             this.eraserbtn = new System.Windows.Forms.ToolBarButton();
             this.imageList1 = new System.Windows.Forms.ImageList(this.components);
-            this.MessageLog = new System.Windows.Forms.RichTextBox();
+            this.splitContainer2 = new System.Windows.Forms.SplitContainer();
             this.LabelStatus = new MetroFramework.Controls.MetroLabel();
             this.LabelTimer = new MetroFramework.Controls.MetroLabel();
-            this.SendButton = new MetroFramework.Controls.MetroButton();
+            this.splitContainer3 = new System.Windows.Forms.SplitContainer();
+            this.MessageLog = new System.Windows.Forms.RichTextBox();
+            this.splitContainer4 = new System.Windows.Forms.SplitContainer();
             this.MessageSend = new MetroFramework.Controls.MetroTextBox();
+            this.SendButton = new MetroFramework.Controls.MetroButton();
             this.toolBar1 = new System.Windows.Forms.ToolBar();
             this.contextMenuStrip1 = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.menuOpen = new System.Windows.Forms.ToolStripMenuItem();
@@ -57,15 +60,10 @@ namespace GarticUmm
             this.openFileDialog1 = new System.Windows.Forms.OpenFileDialog();
             this.saveFileDialog1 = new System.Windows.Forms.SaveFileDialog();
             this.Testlabel = new MetroFramework.Controls.MetroLabel();
-            this.btnWord = new MetroFramework.Controls.MetroButton();
-            this.splitContainer2 = new System.Windows.Forms.SplitContainer();
-            this.splitContainer3 = new System.Windows.Forms.SplitContainer();
-            this.splitContainer4 = new System.Windows.Forms.SplitContainer();
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).BeginInit();
             this.splitContainer1.Panel1.SuspendLayout();
             this.splitContainer1.Panel2.SuspendLayout();
             this.splitContainer1.SuspendLayout();
-            this.contextMenuStrip1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer2)).BeginInit();
             this.splitContainer2.Panel1.SuspendLayout();
             this.splitContainer2.Panel2.SuspendLayout();
@@ -78,6 +76,7 @@ namespace GarticUmm
             this.splitContainer4.Panel1.SuspendLayout();
             this.splitContainer4.Panel2.SuspendLayout();
             this.splitContainer4.SuspendLayout();
+            this.contextMenuStrip1.SuspendLayout();
             this.SuspendLayout();
             // 
             // splitContainer1
@@ -206,6 +205,67 @@ namespace GarticUmm
             this.imageList1.Images.SetKeyName(9, "btn_eraser.png");
             this.imageList1.Images.SetKeyName(10, "btn_white.png");
             // 
+            // splitContainer2
+            // 
+            this.splitContainer2.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.splitContainer2.FixedPanel = System.Windows.Forms.FixedPanel.Panel1;
+            this.splitContainer2.Location = new System.Drawing.Point(0, 0);
+            this.splitContainer2.Name = "splitContainer2";
+            this.splitContainer2.Orientation = System.Windows.Forms.Orientation.Horizontal;
+            // 
+            // splitContainer2.Panel1
+            // 
+            this.splitContainer2.Panel1.Controls.Add(this.LabelStatus);
+            this.splitContainer2.Panel1.Controls.Add(this.LabelTimer);
+            // 
+            // splitContainer2.Panel2
+            // 
+            this.splitContainer2.Panel2.Controls.Add(this.splitContainer3);
+            this.splitContainer2.Size = new System.Drawing.Size(358, 582);
+            this.splitContainer2.SplitterDistance = 42;
+            this.splitContainer2.TabIndex = 0;
+            // 
+            // LabelStatus
+            // 
+            this.LabelStatus.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left)));
+            this.LabelStatus.AutoSize = true;
+            this.LabelStatus.Location = new System.Drawing.Point(17, 11);
+            this.LabelStatus.Name = "LabelStatus";
+            this.LabelStatus.Size = new System.Drawing.Size(110, 19);
+            this.LabelStatus.TabIndex = 3;
+            this.LabelStatus.Text = "Check the picture";
+            // 
+            // LabelTimer
+            // 
+            this.LabelTimer.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.LabelTimer.AutoSize = true;
+            this.LabelTimer.Location = new System.Drawing.Point(321, 11);
+            this.LabelTimer.Name = "LabelTimer";
+            this.LabelTimer.Size = new System.Drawing.Size(21, 19);
+            this.LabelTimer.TabIndex = 0;
+            this.LabelTimer.Text = "10";
+            // 
+            // splitContainer3
+            // 
+            this.splitContainer3.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.splitContainer3.FixedPanel = System.Windows.Forms.FixedPanel.Panel2;
+            this.splitContainer3.Location = new System.Drawing.Point(0, 0);
+            this.splitContainer3.Name = "splitContainer3";
+            this.splitContainer3.Orientation = System.Windows.Forms.Orientation.Horizontal;
+            // 
+            // splitContainer3.Panel1
+            // 
+            this.splitContainer3.Panel1.Controls.Add(this.MessageLog);
+            // 
+            // splitContainer3.Panel2
+            // 
+            this.splitContainer3.Panel2.Controls.Add(this.splitContainer4);
+            this.splitContainer3.Size = new System.Drawing.Size(358, 536);
+            this.splitContainer3.SplitterDistance = 507;
+            this.splitContainer3.TabIndex = 0;
+            // 
             // MessageLog
             // 
             this.MessageLog.Dock = System.Windows.Forms.DockStyle.Fill;
@@ -218,48 +278,30 @@ namespace GarticUmm
             this.MessageLog.TabIndex = 4;
             this.MessageLog.Text = "";
             // 
-            // LabelStatus
+            // splitContainer4
             // 
-            this.LabelStatus.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Left)));
-            this.LabelStatus.AutoSize = true;
-            this.LabelStatus.Location = new System.Drawing.Point(17, 11);
-            this.LabelStatus.Name = "LabelStatus";
-            this.LabelStatus.Size = new System.Drawing.Size(119, 20);
-            this.LabelStatus.TabIndex = 3;
-            this.LabelStatus.Text = "Check the picture";
+            this.splitContainer4.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.splitContainer4.FixedPanel = System.Windows.Forms.FixedPanel.Panel2;
+            this.splitContainer4.Location = new System.Drawing.Point(0, 0);
+            this.splitContainer4.Name = "splitContainer4";
             // 
-            // LabelTimer
+            // splitContainer4.Panel1
             // 
-            this.LabelTimer.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.LabelTimer.AutoSize = true;
-            this.LabelTimer.Location = new System.Drawing.Point(321, 11);
-            this.LabelTimer.Name = "LabelTimer";
-            this.LabelTimer.Size = new System.Drawing.Size(22, 20);
-            this.LabelTimer.TabIndex = 0;
-            this.LabelTimer.Text = "10";
+            this.splitContainer4.Panel1.Controls.Add(this.MessageSend);
             // 
-            // SendButton
+            // splitContainer4.Panel2
             // 
-            this.SendButton.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.SendButton.Location = new System.Drawing.Point(0, 0);
-            this.SendButton.Name = "SendButton";
-            this.SendButton.Size = new System.Drawing.Size(58, 25);
-            this.SendButton.TabIndex = 2;
-            this.SendButton.Text = "Send";
-            this.SendButton.UseSelectable = true;
-            this.SendButton.Click += new System.EventHandler(this.SendButton_Click);
+            this.splitContainer4.Panel2.Controls.Add(this.SendButton);
+            this.splitContainer4.Size = new System.Drawing.Size(358, 25);
+            this.splitContainer4.SplitterDistance = 296;
+            this.splitContainer4.TabIndex = 0;
             // 
             // MessageSend
             // 
-            // 
-            // 
-            // 
             this.MessageSend.CustomButton.Image = null;
-            this.MessageSend.CustomButton.Location = new System.Drawing.Point(258, 1);
+            this.MessageSend.CustomButton.Location = new System.Drawing.Point(272, 1);
             this.MessageSend.CustomButton.Name = "";
-            this.MessageSend.CustomButton.Size = new System.Drawing.Size(21, 21);
+            this.MessageSend.CustomButton.Size = new System.Drawing.Size(23, 23);
             this.MessageSend.CustomButton.Style = MetroFramework.MetroColorStyle.Blue;
             this.MessageSend.CustomButton.TabIndex = 1;
             this.MessageSend.CustomButton.Theme = MetroFramework.MetroThemeStyle.Light;
@@ -283,6 +325,17 @@ namespace GarticUmm
             this.MessageSend.WaterMarkFont = new System.Drawing.Font("Segoe UI", 12F, System.Drawing.FontStyle.Italic, System.Drawing.GraphicsUnit.Pixel);
             this.MessageSend.KeyDown += new System.Windows.Forms.KeyEventHandler(this.MessageSend_KeyDown);
             // 
+            // SendButton
+            // 
+            this.SendButton.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.SendButton.Location = new System.Drawing.Point(0, 0);
+            this.SendButton.Name = "SendButton";
+            this.SendButton.Size = new System.Drawing.Size(58, 25);
+            this.SendButton.TabIndex = 2;
+            this.SendButton.Text = "Send";
+            this.SendButton.UseSelectable = true;
+            this.SendButton.Click += new System.EventHandler(this.SendButton_Click);
+            // 
             // toolBar1
             // 
             this.toolBar1.Dock = System.Windows.Forms.DockStyle.None;
@@ -300,19 +353,19 @@ namespace GarticUmm
             this.menuOpen,
             this.menuSave});
             this.contextMenuStrip1.Name = "contextMenuStrip1";
-            this.contextMenuStrip1.Size = new System.Drawing.Size(114, 52);
+            this.contextMenuStrip1.Size = new System.Drawing.Size(102, 48);
             // 
             // menuOpen
             // 
             this.menuOpen.Name = "menuOpen";
-            this.menuOpen.Size = new System.Drawing.Size(113, 24);
+            this.menuOpen.Size = new System.Drawing.Size(101, 22);
             this.menuOpen.Text = "open";
             this.menuOpen.Click += new System.EventHandler(this.menuOpen_Click);
             // 
             // menuSave
             // 
             this.menuSave.Name = "menuSave";
-            this.menuSave.Size = new System.Drawing.Size(113, 24);
+            this.menuSave.Size = new System.Drawing.Size(101, 22);
             this.menuSave.Text = "save";
             this.menuSave.Click += new System.EventHandler(this.menuSave_Click);
             // 
@@ -322,86 +375,17 @@ namespace GarticUmm
             // 
             // Testlabel
             // 
-            this.Testlabel.Location = new System.Drawing.Point(868, 26);
+            this.Testlabel.Location = new System.Drawing.Point(720, 26);
             this.Testlabel.Name = "Testlabel";
-            this.Testlabel.Size = new System.Drawing.Size(42, 20);
+            this.Testlabel.Size = new System.Drawing.Size(196, 20);
             this.Testlabel.TabIndex = 4;
             this.Testlabel.Text = "Word";
-            // 
-            // btnWord
-            // 
-            this.btnWord.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-            this.btnWord.Location = new System.Drawing.Point(737, 23);
-            this.btnWord.Name = "btnWord";
-            this.btnWord.Size = new System.Drawing.Size(75, 28);
-            this.btnWord.TabIndex = 5;
-            this.btnWord.Text = "Word";
-            this.btnWord.UseSelectable = true;
-            this.btnWord.Click += new System.EventHandler(this.btnWord_Click);
-            // 
-            // splitContainer2
-            // 
-            this.splitContainer2.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.splitContainer2.FixedPanel = System.Windows.Forms.FixedPanel.Panel1;
-            this.splitContainer2.Location = new System.Drawing.Point(0, 0);
-            this.splitContainer2.Name = "splitContainer2";
-            this.splitContainer2.Orientation = System.Windows.Forms.Orientation.Horizontal;
-            // 
-            // splitContainer2.Panel1
-            // 
-            this.splitContainer2.Panel1.Controls.Add(this.LabelStatus);
-            this.splitContainer2.Panel1.Controls.Add(this.LabelTimer);
-            // 
-            // splitContainer2.Panel2
-            // 
-            this.splitContainer2.Panel2.Controls.Add(this.splitContainer3);
-            this.splitContainer2.Size = new System.Drawing.Size(358, 582);
-            this.splitContainer2.SplitterDistance = 42;
-            this.splitContainer2.TabIndex = 0;
-            // 
-            // splitContainer3
-            // 
-            this.splitContainer3.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.splitContainer3.FixedPanel = System.Windows.Forms.FixedPanel.Panel2;
-            this.splitContainer3.Location = new System.Drawing.Point(0, 0);
-            this.splitContainer3.Name = "splitContainer3";
-            this.splitContainer3.Orientation = System.Windows.Forms.Orientation.Horizontal;
-            // 
-            // splitContainer3.Panel1
-            // 
-            this.splitContainer3.Panel1.Controls.Add(this.MessageLog);
-            // 
-            // splitContainer3.Panel2
-            // 
-            this.splitContainer3.Panel2.Controls.Add(this.splitContainer4);
-            this.splitContainer3.Size = new System.Drawing.Size(358, 536);
-            this.splitContainer3.SplitterDistance = 507;
-            this.splitContainer3.TabIndex = 0;
-            // 
-            // splitContainer4
-            // 
-            this.splitContainer4.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.splitContainer4.FixedPanel = System.Windows.Forms.FixedPanel.Panel2;
-            this.splitContainer4.Location = new System.Drawing.Point(0, 0);
-            this.splitContainer4.Name = "splitContainer4";
-            // 
-            // splitContainer4.Panel1
-            // 
-            this.splitContainer4.Panel1.Controls.Add(this.MessageSend);
-            // 
-            // splitContainer4.Panel2
-            // 
-            this.splitContainer4.Panel2.Controls.Add(this.SendButton);
-            this.splitContainer4.Size = new System.Drawing.Size(358, 25);
-            this.splitContainer4.SplitterDistance = 296;
-            this.splitContainer4.TabIndex = 0;
             // 
             // GUGameForm
             // 
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.None;
             this.ClientSize = new System.Drawing.Size(1098, 666);
             this.ContextMenuStrip = this.contextMenuStrip1;
-            this.Controls.Add(this.btnWord);
             this.Controls.Add(this.Testlabel);
             this.Controls.Add(this.splitContainer1);
             this.Font = new System.Drawing.Font("MV Boli", 8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
@@ -416,7 +400,6 @@ namespace GarticUmm
             this.splitContainer1.Panel2.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).EndInit();
             this.splitContainer1.ResumeLayout(false);
-            this.contextMenuStrip1.ResumeLayout(false);
             this.splitContainer2.Panel1.ResumeLayout(false);
             this.splitContainer2.Panel1.PerformLayout();
             this.splitContainer2.Panel2.ResumeLayout(false);
@@ -430,6 +413,7 @@ namespace GarticUmm
             this.splitContainer4.Panel2.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer4)).EndInit();
             this.splitContainer4.ResumeLayout(false);
+            this.contextMenuStrip1.ResumeLayout(false);
             this.ResumeLayout(false);
 
         }
@@ -463,7 +447,6 @@ namespace GarticUmm
         private System.Windows.Forms.ToolBarButton whitebtn;
         private System.Windows.Forms.RichTextBox MessageLog;
         private MetroFramework.Controls.MetroLabel Testlabel;
-        private MetroFramework.Controls.MetroButton btnWord;
         private System.Windows.Forms.SplitContainer splitContainer2;
         private System.Windows.Forms.SplitContainer splitContainer3;
         private System.Windows.Forms.SplitContainer splitContainer4;

--- a/GarticUmm/Form2.cs
+++ b/GarticUmm/Form2.cs
@@ -393,33 +393,31 @@ namespace GarticUmm
                 if(res.Message == Constant.GAME_START)
                 {
                     GUWordForm wordForm = new GUWordForm();
-                    wordForm.DataPass += ReciveWord;
+                    wordForm.DataPass += (string data) =>
+                    {
+                        this.Invoke((MethodInvoker)(delegate ()
+                        {
+                            this.Testlabel.Text = data;
+                        }));
+                    }; ;
                     wordForm.ShowDialog();
                 }
             }
 
             if(res.Code == 2002)
             {
-                if(res.Message == Constant.ERROR_NOT_ENOUGH_PLAYER)
+                if (res.Message == Constant.ERROR_NOT_ENOUGH_PLAYER)
                 {
                     MessageBox.Show("You can't start a game until you have at least three players!");
+                    return;
+                }
+
+                if (res.Message == Constant.ERROR_ALREADY_GAME_IS_RUNNING)
+                {
+                    MessageBox.Show("Game is already running!");
+                    return;
                 }
             }
-        }
-        
-        //제시어 입력창 생성 및 저장(임시)
-        private List<string> words;//WordForm에서 입력받은 제시어 저장할 리스트
-        private void btnWord_Click(object sender, EventArgs e)
-        {
-            GUWordForm wordForm = new GUWordForm();
-            wordForm.DataPass += new GUWordForm.DataPassEventHandler(ReciveWord);
-            wordForm.ShowDialog();
-        }
-        public void ReciveWord(string data)//WordForm에서 받아온 제시어 저장 및 출력
-        {
-            words = new List<string>();
-            words.Add(data);
-            Testlabel.Text = data;
         }
 
         private void sendPaint(DrawLineHistroy histroy)

--- a/GarticUmm/Form2.resx
+++ b/GarticUmm/Form2.resx
@@ -125,7 +125,7 @@
         AAEAAAD/////AQAAAAAAAAAMAgAAAFdTeXN0ZW0uV2luZG93cy5Gb3JtcywgVmVyc2lvbj00LjAuMC4w
         LCBDdWx0dXJlPW5ldXRyYWwsIFB1YmxpY0tleVRva2VuPWI3N2E1YzU2MTkzNGUwODkFAQAAACZTeXN0
         ZW0uV2luZG93cy5Gb3Jtcy5JbWFnZUxpc3RTdHJlYW1lcgEAAAAERGF0YQcCAgAAAAkDAAAADwMAAACk
-        GQAAAk1TRnQBSQFMAgEBCwEAAdABAAHQAQABIAEAASABAAT/AQkBAAj/AUIBTQE2AQQGAAE2AQQCAAEo
+        GQAAAk1TRnQBSQFMAgEBCwEAAdgBAAHYAQABIAEAASABAAT/AQkBAAj/AUIBTQE2AQQGAAE2AQQCAAEo
         AwABgAMAAWADAAEBAQABCAYAATAYAAGAAgABgAMAAoABAAGAAwABgAEAAYABAAKAAgADwAEAAcAB3AHA
         AQAB8AHKAaYBAAEzBQABMwEAATMBAAEzAQACMwIAAxYBAAMcAQADIgEAAykBAANVAQADTQEAA0IBAAM5
         AQABgAF8Af8BAAJQAf8BAAGTAQAB1gEAAf8B7AHMAQABxgHWAe8BAAHWAucBAAGQAakBrQIAAf8BMwMA
@@ -245,9 +245,6 @@
   </metadata>
   <metadata name="saveFileDialog1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>608, 17</value>
-  </metadata>
-  <metadata name="btnWord.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
   </metadata>
   <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>67</value>

--- a/GarticUmm/SharedObject.cs
+++ b/GarticUmm/SharedObject.cs
@@ -10,8 +10,8 @@ namespace SharedObject
 {
     class Constant
     {
-        //public static readonly IPAddress LOCALHOST = IPAddress.Parse("127.0.0.1");
-        public static readonly IPAddress LOCALHOST = IPAddress.Parse("192.168.182.194");
+        public static readonly IPAddress LOCALHOST = IPAddress.Parse("127.0.0.1");
+        //public static readonly IPAddress LOCALHOST = IPAddress.Parse("192.168.182.194");
         public static readonly int PORT = 43673;
         public static readonly Encoding UTF8 = Encoding.GetEncoding("UTF-8");
 
@@ -19,6 +19,7 @@ namespace SharedObject
         public static readonly string GAME_START = "GAME_START";
 
         // Error state
+        public static readonly string ERROR_ALREADY_GAME_IS_RUNNING = "ERROR_ALREADY_GAME_IS_RUNNING";
         public static readonly string ERROR_NOT_ENOUGH_PLAYER = "ERROR_NOT_ENOUGH_PLAYER";
 
     }

--- a/GarticUmm/UmmQueue.cs
+++ b/GarticUmm/UmmQueue.cs
@@ -21,9 +21,10 @@ namespace UmmQueue
 
     class PersonQueue<T> : IEnumerable<T>
     {
-        public Node<T> first;
-        public Node<T> last;
-        int size;
+        private Node<T> first;
+        private Node<T> last;
+        private int size;
+
         public PersonQueue()
         {
             this.first = null;
@@ -31,9 +32,17 @@ namespace UmmQueue
             size = 0;
         }
 
-        public void enQueue(T person)
+        public T Peek()
         {
-            Node<T> newnode = new Node<T>(person);
+            if (first == null)
+                return default(T);
+
+            return first.value;
+        }
+
+        public void Enqueue(T item)
+        {
+            Node<T> newnode = new Node<T>(item);
             if (first == null)
             {
                 first = newnode;
@@ -47,7 +56,7 @@ namespace UmmQueue
             size++;
         }
 
-        public T deQueue()
+        public T Dequeue()
         {
             if (first == null)
                 return default(T);
@@ -62,19 +71,18 @@ namespace UmmQueue
             return result.value;
         }
 
-        public T pop(T index)
+        public T Pop(T target)
         {
             if (first == null)
                 return default(T);
 
             Node<T> previous = null;
             Node<T> current = first;
-
             Node<T> result = null;
 
             while (current != null)
             {
-                if (current.value.Equals(index))
+                if (current.value.Equals(target))
                 {
                     result = current;
 
@@ -82,42 +90,73 @@ namespace UmmQueue
                     {
                         first = current.next;
                         if (first == null)
+                        {
                             last = null;
+                        }
                     }
 
                     if (previous != null)
+                    {
                         previous.next = current.next;
+                    }
 
                     if (current.next == null)
+                    {
                         last = previous;
+                    }
 
                 }
                 previous = current;
                 current = current.next;
             }
-            size--;
 
             if (result == null)
                 return default(T);
 
+            size--;
             return result.value;
         }
 
-        public T search(int idx)
+        public int GetIndexOf(T target)
         {
-            idx--;
-            Node<T> current = first;
-            int currentIndex = 0;
-            while (current != null)
+            Node<T> cursor = first;
+            int idx = 0;
+
+            while (cursor != null)
             {
-                if (currentIndex == idx)
+                if (cursor.value.Equals(target))
                 {
-                    return current.value;
+                    return idx;
                 }
-                current = current.next;
-                currentIndex++;
+                cursor = cursor.next;
+                idx++;
             }
-            throw new IndexOutOfRangeException("Index is out of range");
+
+            return -1;
+        }
+
+        public T GetNextItemOf(T target)
+        {
+            Node<T> cursor = first;
+
+            if (first == null)
+                return default(T);
+
+            while (cursor != null)
+            {
+                if (cursor.value.Equals(target))
+                {
+                    // 끝까지 도달했으면 맨 앞의 값 반환 (Circular queue)
+                    if (cursor.next == null)
+                    {
+                        return first.value;
+                    }
+                    return cursor.next.value;
+                }
+                cursor = cursor.next;
+            }
+
+            return default(T);
         }
 
 


### PR DESCRIPTION
아래의 이슈를 해결했습니다.
---
- `clients` 배열 사용 중단. (대신 `readyQueue`, `playQueue` 2개로 해결)
- queue의 제네릭으로 `int` 대신 `HandleClient` 사용.
- UmmQueue 메서드 수정 및 이름 변경.
- 제시어 입력시 Form2의 라벨이 바뀌도록 delegate 함수 사용.
- 게임 진행 중에 또 게임 시작하는 명령어 입력시 에러 문구 출력하도록 에러 상황 및 메세지 추가.
  (`ERROR_ALREADY_GAME_IS_RUNNING`)

그 외에도 queue에 `Peek()` 함수 추가, UmmQueue 클래스의 내부 멤버 은닉화를 진행했습니다.

</br>

해결해야 할 것
---
그림이 단순히 code == 5000 으로 도착한다고 해서 보내면 안됩니다.
일단 서버에 제시어끼리 그림을 모아 저장해야 합니다.
이후 모든 플레이어의 그림이 제출 돼야지만 다음 사람에게 그림을 전달할 수 있습니다. (동기화 목적)

그림을 관리하는 방식은 주석으로 남겨놨습니다.
하지만, 다음 플레이어를 어떤 기준으로 선택할 지에 대한 기준을 정하지 못했습니다.

제 생각에는 `Node`에서 제네릭을 포기하고 무조건 `HandleClient`만 받아올 수 있도록 설정한 뒤,
멤버 변수로 string `present`를 추가하여 `특정 client`와 `그 사람의 제시어`를 `Node`에서 관리하도록 합니다.
이후 제시어를 입력으로 넣으면 `해당 제시어를 입력한 HandleClient를 반환하는` PersonQueue의 메서드를 추가합니다.
그럼 아래와 같이 진행할 수 있습니다.

1. 모든 플레이어가 제시어를 입력함.
2. 모든 플레이어가 제시어에 해당하는 그림을 그림.
3. 모든 플레이어가 그림을 제출함.
  이 때 `imageList`의 상태는 다음과 같아집니다. (의미상 `imageMap`으로 짓는게 더 나을 듯)
  ```json
  {
      "제시어A": ["그림A1"],
      "제시어B": ["그림B1"],
      "제시어C": ["그림C1"],
  }
  ``` 
4. `imageList.Keys()`로 제시어 배열을 받아옴 (`["제시어A", "제시어B", "제시어C"]`)
5. `foreach`로 아래 코드 반복
  ```csharp
  HandleClient fromClient = playQueue.GetPlayerFromPresent(present);
  HandleClient toClient = playQueue.GetNextItemOf(fromClient);
  toClient.StreamWriter.WriteLine("5000," + imageList[present][turn - 1]);
  ```
6. `turn++`

위 내용은 초안이고 실제로는 개발하며 해결해야 할 듯 합니다.