### PR TITLE
제시어 중복 허용 및 제시어 입력에서 쉼표를 포함 하거나 빈칸일 경우 다시 입력 구현

### DIFF
--- a/GarticUmm/Form3.cs
+++ b/GarticUmm/Form3.cs
@@ -22,6 +22,16 @@ namespace GarticUmm
 
         private void btnSend_Click(object sender, EventArgs e)
         {
+            if (Wordbox.Text.Contains(","))
+            {
+                MessageBox.Show("You can't use \",\"!");
+                return;
+            }
+            if (Wordbox.Text == "")
+            {
+                MessageBox.Show("Enter your word!");
+                return;
+            }
             DataPass(Wordbox.Text); // 버튼 클릭시 이벤트 호출
         }
 
@@ -29,6 +39,16 @@ namespace GarticUmm
         {
             if(e.KeyCode == Keys.Enter)
             {
+                if (Wordbox.Text.Contains(","))
+                {
+                    MessageBox.Show("You can't use \",\"!");
+                    return;
+                }
+                if (Wordbox.Text == "")
+                {
+                    MessageBox.Show("Enter your word!");
+                    return;
+                }
                 DataPass(Wordbox.Text); // 버튼 클릭시 이벤트 호출
             }
             if (e.KeyCode == Keys.Escape)

--- a/GarticUmm/SocketServer.cs
+++ b/GarticUmm/SocketServer.cs
@@ -182,8 +182,10 @@ namespace GarticUmm
             // 제시어 입력이 들어왔을 때
             if (res.Code == 3004)
             {
-                playQueue.SetPresent(target, res.Message);
-                imageMap.Add(res.Message, new List<string>());
+                string idpresent;
+                idpresent = target.ID + " - " + res.Message;
+                playQueue.SetPresent(target, idpresent);
+                imageMap.Add(idpresent, new List<string>());
                 readyPlayers++;
 
                 // 전부 제시어 입력을 완료했을 때


### PR DESCRIPTION
1. 제시어 중복 구현: 서버가 제시어를 받을 때 앞에 플레이어의 id를 붙여 저장.
2. 제시어 또는 정답 입력에서 쉼표를 포함 하거나 빈칸일 경우 다시 입력 구현: Form3에서 WordBox의 텍스트가 쉼표를 포함하고 있거나 빈칸이라면 메시지 박스를 띄우고, 서버로 제시어를 보내지 않음.